### PR TITLE
state corrected for 2 word answers

### DIFF
--- a/scripts/services.js
+++ b/scripts/services.js
@@ -38,7 +38,7 @@ export const bannerServices = () => {
 
   for (const service of services) {
     serviceArray.push(
-      `<span data-type="banner-service" data-id=${service.id} data-name=${service.name}> ${service.name}</span>`
+      `<span data-type="banner-service" data-id="${service.id}" data-name="${service.name}"> ${service.name}</span>`
     );
   }
 


### PR DESCRIPTION
state corrected for 2 word answers, by adding quotes to the state for .name and .id.