### PR TITLE
services function removed due to redundancy

### DIFF
--- a/scripts/services.js
+++ b/scripts/services.js
@@ -45,24 +45,3 @@ export const bannerServices = () => {
 
   return html;
 };
-
-// function for creating servicesHTML to be invoked in area.js
-export const Services = () => {
-  let html = `<article class="services">`;
-
-  for (const service of services) {
-    html += `
-    <ul>
-        <li data-type="service" 
-        data-id=${service.id}
-        data-name=${service.name} >
-        ${service.name}
-        </li>
-    </ul>
-    `;
-  }
-
-  html += "</article>";
-
-  return html;
-};


### PR DESCRIPTION
While bannerServices() is actually rendered to the DOM, the vanilla Services() function was never actually called. It was originally poised to be utilized in the areas.js module, but we ended up grabbing that information in a different way. 

So it was unneeded and deleted. Yeet. 